### PR TITLE
Better handle of double value in screen size

### DIFF
--- a/Nitro Stream/ViewModel/NitroStreamViewModel.cs
+++ b/Nitro Stream/ViewModel/NitroStreamViewModel.cs
@@ -66,8 +66,8 @@ namespace Nitro_Stream.ViewModel
 
                         args.Append("-l ");
                         args.Append((_ViewSettings.ViewMode == Model.Orientations.Vertical) ? "0 " : "1 ");
-                        args.Append("-t " + _ViewSettings.TopScale.ToString() + " ");
-                        args.Append("-b " + _ViewSettings.BottomScale.ToString());
+                        args.Append("-t " + _ViewSettings.TopScale.ToString().Replace(',','.') + " ");
+                        args.Append("-b " + _ViewSettings.BottomScale.ToString().Replace(',','.'));
 
                         System.Diagnostics.ProcessStartInfo p = new System.Diagnostics.ProcessStartInfo(_ViewSettings.ViewerPath);
                         p.Verb = "runas";


### PR DESCRIPTION
Added a tweak to better handle the value of screen size.
Beacause if the arg was "1,8" always where intepreted as "1".
Now replacing the ',' with a dot the arg works correctly.
